### PR TITLE
BugFix - event_flash/player_flash toujours rouge / toujours 10 frames

### DIFF
--- a/src/Commands.rb
+++ b/src/Commands.rb
@@ -1415,8 +1415,9 @@ module RMECommands
       Math.hypot(*args).to_i
     end
 
-    def event_flash(id, color, duration)
-      event(id).k_sprite.flash(get_color("red"), 10)
+    def event_flash(id, _color, duration)
+      color = _color.is_a?(String) ? get_color(_color) : _color
+      event(id).k_sprite.flash(color, duration)
     end
 
     def player_flash(color, duration)


### PR DESCRIPTION
## Problème
Le soucis était que la commande event_flash flashait toujours l'évènement avec la couleur rouge et pendant 10 frames.

## Solution
Dans le code les valeurs étaient restée en dur. Il a juste suffit d'utiliser les paramètres passés à la commande.