### PR TITLE
Ajout de la commande mouse_hover_window?

### DIFF
--- a/src/Commands.rb
+++ b/src/Commands.rb
@@ -3154,6 +3154,14 @@ module RMECommands
       return SceneManager.scene.windows[id].y unless y
       SceneManager.scene.windows[id].y = y
     end
+    
+    #--------------------------------------------------------------------------
+    # * Point in window
+    #--------------------------------------------------------------------------
+    
+    def mouse_hover_window?(id)
+      SceneManager.scene.windows[id].mouse_hover? if SceneManager.scene.windows[id]
+    end
 
     append_commands
   end

--- a/src/Doc.rb
+++ b/src/Doc.rb
@@ -6333,6 +6333,11 @@ link_method_documentation 'Command.window_y',
     :"*y" => ["Coordonnée Y de la fenêtre", :Fixnum],
 	}, true # Maybe changed
 register_command :window, 'Command.window_y'
+	
+link_method_documentation 'Command.mouse_hover_window?',
+	'Renvoie true si la souris survole la fenêtre, false sinon.',
+ 	{:id => ["ID de la fenêtre", :Fixnum]}, true
+register_command :window, 'Command.mouse_hover_window?'
 
 link_method_documentation 'Command.between',
 	'Donne la distance entre deux points',

--- a/src/EvEx.rb
+++ b/src/EvEx.rb
@@ -2005,6 +2005,16 @@ class Window_Base
   # * Include Window movement
   #--------------------------------------------------------------------------
   include Window_Movement
+  #--------------------------------------------------------------------------
+  # * mouse_hover?
+  #--------------------------------------------------------------------------
+  def mouse_hover?
+    posX = Mouse.x - self.x
+    posY = Mouse.y - self.y
+    posX -= viewport.x if (viewport)
+    posY -= viewport.y if (viewport)
+    return(posX.between?(0, self.width-1) && posY.between?(0, self.height-1))
+  end
 end
 
 #==============================================================================


### PR DESCRIPTION
J'ai ajouté la commande mouse_hover_window? pour vérifier le survole d'une fenêtre avec la souris.

Utile dans mon cas pour changer le focus d'une window_selectable à une autre en passant la souris par dessus celle voulue.