### PR TITLE
Feature/commands/event character commands

### DIFF
--- a/src/Commands.rb
+++ b/src/Commands.rb
@@ -1428,6 +1428,11 @@ module RMECommands
       return event(id).direction unless value
       event(id).set_direction(value)
     end
+    def event_change_character(id, character_name, character_index)
+      event(id).set_graphic(character_name, character_index)
+    end
+    def event_character_name(id); event(id).character_name; end
+    def event_character_index(id); event(id).character_index; end
     def player_x; event(0).x; end
     def player_y; event(0).y; end
     def player_screen_x; event(0).screen_x; end

--- a/src/Doc.rb
+++ b/src/Doc.rb
@@ -1310,6 +1310,23 @@ register_command :standard, 'Command.unflash_rect'
                         {:id => ["ID de l'évènement (0 pour héros)", :Fixnum]}, true
   register_command :event, "Command.event_pixel_y"
 
+  link_method_documentation "Command.event_change_character",
+                        "Change l\'apparence d'un évènement référencé par son ID",
+                        {:id => ["ID de l'évènement (0 pour héros)", :Fixnum],
+                         :character_name => ["Nom du caractère", :String],
+                         :character_index => ["ID du caractère", :Fixnum]}, true
+  register_command :event, 'Command.event_change_character'
+
+  link_method_documentation "Command.event_character_name",
+                        "Renvoie le nom du charset utilisé pour l'apparence de l'évènement référencé par son ID",
+                        {:id => ["ID de l'évènement (0 pour héros)", :Fixnum]}, true
+  register_command :event, "Command.event_character_name"
+
+  link_method_documentation "Command.event_character_index",
+                        "Renvoie l'ID du character sur le charset l'évènement référencé par son ID",
+                        {:id => ["ID de l'évènement (0 pour héros)", :Fixnum]}, true
+  register_command :event, "Command.event_character_index"
+
   link_method_documentation "Command.event_direction",
                         "Renvoie (ou change) la direction (2 pour le haut, 8, pour le bas, 4 pour la gauche , 6 pour la droite ) de l'évènement référencé par son ID",
                         {:id => ["ID de l'évènement (0 pour héros)", :Fixnum],


### PR DESCRIPTION
(Résoud #201)

## Nouvelles commandes ajoutées
- `event_character_name(id) -> String`
  - Renvoie le nom du charset de l’évent référencé par l'id passé en paramètre.
  - id = 0 étant le player.
- `event_character_index(id) -> Integer`
  - Renvoie l'index du character de l’évent référencé par l'id passé en paramètre.
  - id = 0 étant le player.
- `event_change_character(id, character_name, character_index)`
  - Change l'apparence (charset, index du chara) de l'évent référencé par l'id passé en paramètre.
  - id = 0 étant le player.

Testées sur Event, Player et Follower