### PR TITLE
Fix problems about skip_title and return_to_title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Additions
 - Add command `reset` (@BastienDuplessier, reported by @YendaHusk)
 
+### Bug fixes
+- Fix Game_End background that wasn't disposed on skip_title activated (@BastienDuplessier, reported by @Zer0Zer0x)
+
 ### Misc
 - Various fixes in the documentation (reported by @aureliendossantos and @Zer0Zer0x)
 

--- a/RME.rb
+++ b/RME.rb
@@ -10707,7 +10707,7 @@ class Scene_End
     end
     close_command_window
     fadeout_all
-    SceneManager.run
+    SceneManager.reset
   end
 
 end

--- a/src/EvEx.rb
+++ b/src/EvEx.rb
@@ -4653,7 +4653,7 @@ class Scene_End
     end
     close_command_window
     fadeout_all
-    SceneManager.run
+    SceneManager.reset
   end
 
 end


### PR DESCRIPTION
## Changes
- Fix background that was not disposed when calling "Return to title" while being in skip_title mode

Fixes #245 