### PR TITLE
Camera was moving when teleporting the player in current map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix `Float DomainError : Infinity` when losing focus (@BastienDuplessier, reported by @Zer0xxxx)
 - Fix `create_text_window`, now can create empty text windows (@BastienDuplessier, reported by @Zer0xxxx)
 - Fix `text_show` with empty content and centered (@BastienDuplessier, reported by @aureliendossantos)
+- Teleport/Moving player will not recenter camera anymore if camera is locked (@BastienDuplessier, reported by @LucasDevos)
 
 ### Misc
 - Various fixes in the documentation (reported by @aureliendossantos, @Zer0xxxx, @grrim, @YendaHusk)

--- a/RME.rb
+++ b/RME.rb
@@ -8930,6 +8930,18 @@ class Game_Map
     return if @camera_lock.include?(:y)
     rm_extender_scroll_up(distance)
   end
+  #--------------------------------------------------------------------------
+  # * Is X axis of the camera locked ?
+  #--------------------------------------------------------------------------
+  def camera_x_locked?
+    $game_map.camera_lock.include?(:x)
+  end
+  #--------------------------------------------------------------------------
+  # * Is Y axis of the camera locked ?
+  #--------------------------------------------------------------------------
+  def camera_y_locked?
+    $game_map.camera_lock.include?(:y)
+  end
 
   #--------------------------------------------------------------------------
   # * Get the map rectangle
@@ -15007,11 +15019,11 @@ module RMECommands
 
     def camera_lock_x; $game_map.camera_lock << :x; end
     def camera_unlock_x; $game_map.camera_lock.delete(:x); end
-    def camera_x_locked?; $game_map.camera_lock.include?(:x); end
+    def camera_x_locked?; $game_map.camera_x_locked?; end
 
     def camera_lock_y; $game_map.camera_lock << :y; end
     def camera_unlock_y; $game_map.camera_lock.delete(:y); end
-    def camera_y_locked?; $game_map.camera_lock.include?(:y); end
+    def camera_y_locked?; $game_map.camera_y_locked?; end
 
     def camera_change_focus(event_id)
       e = event(event_id)

--- a/RME.rb
+++ b/RME.rb
@@ -7775,6 +7775,7 @@ class Game_Player
   #--------------------------------------------------------------------------
   alias_method :rme_update_scroll, :update_scroll
   alias_method :rme_refresh, :refresh
+  alias_method :rme_center, :center
   def update_scroll(last_real_x, last_real_y)
     return if $game_map.target_camera != self
     rme_update_scroll(last_real_x, last_real_y)
@@ -7791,6 +7792,19 @@ class Game_Player
   def refresh
     rme_refresh
     restore_oxy
+  end
+  #--------------------------------------------------------------------------
+  # * Set Map Display Position to Center of Screen
+  #--------------------------------------------------------------------------
+  def center(x, y)
+    return unless $game_map.target_camera == self
+    if $game_map.camera_x_locked?
+      $game_map.set_display_pos($game_map.display_x, y - center_y)
+    elsif $game_map.camera_y_locked?
+      $game_map.set_display_pos(x - center_x, $game_map.display_x)
+    else
+      rme_center(x, y)
+    end
   end
 end
 

--- a/src/Commands.rb
+++ b/src/Commands.rb
@@ -3782,11 +3782,11 @@ module RMECommands
 
     def camera_lock_x; $game_map.camera_lock << :x; end
     def camera_unlock_x; $game_map.camera_lock.delete(:x); end
-    def camera_x_locked?; $game_map.camera_lock.include?(:x); end
+    def camera_x_locked?; $game_map.camera_x_locked?; end
 
     def camera_lock_y; $game_map.camera_lock << :y; end
     def camera_unlock_y; $game_map.camera_lock.delete(:y); end
-    def camera_y_locked?; $game_map.camera_lock.include?(:y); end
+    def camera_y_locked?; $game_map.camera_y_locked?; end
 
     def camera_change_focus(event_id)
       e = event(event_id)

--- a/src/EvEx.rb
+++ b/src/EvEx.rb
@@ -1720,6 +1720,7 @@ class Game_Player
   #--------------------------------------------------------------------------
   alias_method :rme_update_scroll, :update_scroll
   alias_method :rme_refresh, :refresh
+  alias_method :rme_center, :center
   def update_scroll(last_real_x, last_real_y)
     return if $game_map.target_camera != self
     rme_update_scroll(last_real_x, last_real_y)
@@ -1736,6 +1737,19 @@ class Game_Player
   def refresh
     rme_refresh
     restore_oxy
+  end
+  #--------------------------------------------------------------------------
+  # * Set Map Display Position to Center of Screen
+  #--------------------------------------------------------------------------
+  def center(x, y)
+    return unless $game_map.target_camera == self
+    if $game_map.camera_x_locked?
+      $game_map.set_display_pos($game_map.display_x, y - center_y)
+    elsif $game_map.camera_y_locked?
+      $game_map.set_display_pos(x - center_x, $game_map.display_x)
+    else
+      rme_center(x, y)
+    end
   end
 end
 

--- a/src/EvEx.rb
+++ b/src/EvEx.rb
@@ -2875,6 +2875,18 @@ class Game_Map
     return if @camera_lock.include?(:y)
     rm_extender_scroll_up(distance)
   end
+  #--------------------------------------------------------------------------
+  # * Is X axis of the camera locked ?
+  #--------------------------------------------------------------------------
+  def camera_x_locked?
+    $game_map.camera_lock.include?(:x)
+  end
+  #--------------------------------------------------------------------------
+  # * Is Y axis of the camera locked ?
+  #--------------------------------------------------------------------------
+  def camera_y_locked?
+    $game_map.camera_lock.include?(:y)
+  end
 
   #--------------------------------------------------------------------------
   # * Get the map rectangle


### PR DESCRIPTION
## Changes
- Move `camera_xy_locked?` implementations from `Commands` to `Game_Map`
- Patch `Game_Player#center` to adapt to camera lock commands

Tested with :
- Event command : Teleport
- RME command : `event_transfert`
- RME command : `player_teleport`

Fixes #385 