### PR TITLE
Add Windowskin and tone commands for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add command `abs` (@xvw, reported by @Zer0xxxx)
 - Add command `include_common_event` (@BastienDuplessier)
 - Add command `get_squares_between` and `get_squares_between_events` (@BastienDuplessier)
+- Add commands `window_change_windowskin`, `window_change_tone`, `window_use_default_windowskin, `window_use_default_tone` (@BastienDuplessier, reported by @Zer0xxxx)
 
 ### Bug fixes
 - Fix Game_End background that wasn't disposed on `skip_title` activated (@BastienDuplessier, reported by @Zer0xxxx)

--- a/RME.rb
+++ b/RME.rb
@@ -15331,6 +15331,22 @@ module RMECommands
       SceneManager.scene.windows[id].y = y
     end
 
+    def window_change_windowskin(id, filename)
+      SceneManager.scene.windows[id].change_windowskin(filename)
+    end
+
+    def window_change_tone(id, tone)
+      SceneManager.scene.windows[id].change_tone(tone)
+    end
+
+    def window_use_default_windowskin(id)
+      SceneManager.scene.windows[id].use_default_windowskin
+    end
+
+    def window_use_default_tone(id)
+      SceneManager.scene.windows[id].use_default_tone
+    end
+
     def fresh_window_id
       SceneManager.scene.fresh_window_id
     end

--- a/RME.rb
+++ b/RME.rb
@@ -6174,6 +6174,13 @@ module Cache
     end
     return Cache.picture(name)
   end
+
+  #--------------------------------------------------------------------------
+  # * Get Battle Background (Floor) Graphic
+  #--------------------------------------------------------------------------
+  def self.windowskin(filename)
+    load_bitmap("Graphics/Windowskins/", filename)
+  end
 end
 
 
@@ -8199,6 +8206,7 @@ class Window_Base
   alias_method :rm_extender_convert_escape_characters, :convert_escape_characters
   alias_method :rm_extender_initialize, :initialize
   alias_method :rm_extender_update, :update
+  alias_method :rm_extender_update_tone, :update_tone
   #--------------------------------------------------------------------------
   # * Object Initialize
   #--------------------------------------------------------------------------
@@ -8213,6 +8221,13 @@ class Window_Base
   def update
     rm_extender_update
     mod_update
+  end
+  #--------------------------------------------------------------------------
+  # * Update Tone
+  #--------------------------------------------------------------------------
+  def update_tone
+    return if @custom_tone
+    rm_extender_update_tone
   end
   #--------------------------------------------------------------------------
   # * Preconvert Control Characters
@@ -8249,6 +8264,31 @@ class Window_Base
     posX -= viewport.x if (viewport)
     posY -= viewport.y if (viewport)
     return(posX.between?(0, self.width-1) && posY.between?(0, self.height-1))
+  end
+  #--------------------------------------------------------------------------
+  # * Change Windowskin
+  #--------------------------------------------------------------------------
+  def change_windowskin(filename)
+    self.windowskin = Cache.windowskin(filename)
+  end
+  #--------------------------------------------------------------------------
+  # * Change Window tone
+  #--------------------------------------------------------------------------
+  def change_tone(tone)
+    @custom_tone = true
+    self.tone.set(tone)
+  end
+  #--------------------------------------------------------------------------
+  # * Use default windowskin
+  #--------------------------------------------------------------------------
+  def use_default_windowskin
+    self.windowskin = Cache.system("Window")
+  end
+  #--------------------------------------------------------------------------
+  # * Use default window tone
+  #--------------------------------------------------------------------------
+  def use_default_tone
+    @custom_tone = false
   end
 end
 

--- a/doc.js
+++ b/doc.js
@@ -1787,7 +1787,13 @@ var documentation = [
 {"name":"window_y", "description":"Change la coordonnée Y de la fenêtre référencée par son ID, si aucun Y n'est donné, la commande renverra la valeur actuelle de y", "returnable":true,"parameters":[{"name":"id", "desc":"ID de la fenêtre", "type":"Fixnum"},
 {"name":"*y", "desc":"Coordonnée Y de la fenêtre", "type":"Fixnum"}]},
 {"name":"fresh_window_id", "description":"Génère un ID non utilisé pour une window", "returnable":true,"parameters":[]},
-{"name":"mouse_hover_window?", "description":"Renvoie true si la souris survole la fenêtre, false sinon.", "returnable":true,"parameters":[{"name":"id", "desc":"ID de la fenêtre", "type":"Fixnum"}]}
+{"name":"mouse_hover_window?", "description":"Renvoie true si la souris survole la fenêtre, false sinon.", "returnable":true,"parameters":[{"name":"id", "desc":"ID de la fenêtre", "type":"Fixnum"}]},
+{"name":"window_change_windowskin", "description":"Change le windowskin de la fenêtre spécifiée.", "returnable":true,"parameters":[{"name":"id", "desc":"ID de la fenêtre", "type":"Fixnum"},
+{"name":"filename", "desc":"Nom du fichier dans Graphics/Windowskins", "type":"String"}]},
+{"name":"window_change_tone", "description":"Change le ton de la fenêtre spécifiée.", "returnable":true,"parameters":[{"name":"id", "desc":"ID de la fenêtre", "type":"Fixnum"},
+{"name":"tone", "desc":"Teinte (utilisez la commande 'tone')", "type":"Tone"}]},
+{"name":"window_use_default_windowskin", "description":"Change le windowskin par celui par défaut.", "returnable":true,"parameters":[{"name":"id", "desc":"ID de la fenêtre", "type":"Fixnum"}]},
+{"name":"window_use_default_tone", "description":"Chante le ton par celui par défaut.", "returnable":true,"parameters":[{"name":"id", "desc":"ID de la fenêtre", "type":"Fixnum"}]}
 ]},
 {"name":"Fenêtre de jeu","desc":"Commandes de manipulation de la fenêtre de jeu","commands":[
 {"name":"game_window_rect", "description":"Renvoie le rectangle correspondant à la fenêtre de jeu", "returnable":true,"parameters":[]}

--- a/src/Commands.rb
+++ b/src/Commands.rb
@@ -3997,6 +3997,22 @@ module RMECommands
       SceneManager.scene.windows[id].y = y
     end
 
+    def window_change_windowskin(id, filename)
+      SceneManager.scene.windows[id].change_windowskin(filename)
+    end
+
+    def window_change_tone(id, tone)
+      SceneManager.scene.windows[id].change_tone(tone)
+    end
+
+    def window_use_default_windowskin(id)
+      SceneManager.scene.windows[id].use_default_windowskin
+    end
+
+    def window_use_default_tone(id)
+      SceneManager.scene.windows[id].use_default_tone
+    end
+
     def fresh_window_id
       SceneManager.scene.fresh_window_id
     end

--- a/src/Doc.rb
+++ b/src/Doc.rb
@@ -6892,6 +6892,36 @@ link_method_documentation 'Command.mouse_hover_window?',
    {:id => ["ID de la fenêtre", :Fixnum]}, true
 register_command :window, 'Command.mouse_hover_window?'
 
+link_method_documentation 'Command.window_change_windowskin',
+  'Change le windowskin de la fenêtre spécifiée.',
+   {
+    :id => ["ID de la fenêtre", :Fixnum],
+    :filename => ["Nom du fichier dans Graphics/Windowskins", :String],
+  }, true # Maybe changed
+register_command :window, 'Command.window_change_windowskin'
+
+link_method_documentation 'Command.window_change_tone',
+  'Change le ton de la fenêtre spécifiée.',
+   {
+    :id => ["ID de la fenêtre", :Fixnum],
+    :tone => ["Teinte (utilisez la commande 'tone')", :Tone],
+  }, true # Maybe changed
+register_command :window, 'Command.window_change_tone'
+
+link_method_documentation 'Command.window_use_default_windowskin',
+  'Change le windowskin par celui par défaut.',
+   {
+    :id => ["ID de la fenêtre", :Fixnum],
+  }, true # Maybe changed
+register_command :window, 'Command.window_use_default_windowskin'
+
+link_method_documentation 'Command.window_use_default_tone',
+  'Chante le ton par celui par défaut.',
+   {
+    :id => ["ID de la fenêtre", :Fixnum],
+  }, true # Maybe changed
+register_command :window, 'Command.window_use_default_tone'
+
 link_method_documentation 'Command.between',
   'Donne la distance entre deux points',
    {

--- a/src/EvEx.rb
+++ b/src/EvEx.rb
@@ -76,6 +76,13 @@ module Cache
     end
     return Cache.picture(name)
   end
+
+  #--------------------------------------------------------------------------
+  # * Get Battle Background (Floor) Graphic
+  #--------------------------------------------------------------------------
+  def self.windowskin(filename)
+    load_bitmap("Graphics/Windowskins/", filename)
+  end
 end
 
 
@@ -2101,6 +2108,7 @@ class Window_Base
   alias_method :rm_extender_convert_escape_characters, :convert_escape_characters
   alias_method :rm_extender_initialize, :initialize
   alias_method :rm_extender_update, :update
+  alias_method :rm_extender_update_tone, :update_tone
   #--------------------------------------------------------------------------
   # * Object Initialize
   #--------------------------------------------------------------------------
@@ -2115,6 +2123,13 @@ class Window_Base
   def update
     rm_extender_update
     mod_update
+  end
+  #--------------------------------------------------------------------------
+  # * Update Tone
+  #--------------------------------------------------------------------------
+  def update_tone
+    return if @custom_tone
+    rm_extender_update_tone
   end
   #--------------------------------------------------------------------------
   # * Preconvert Control Characters
@@ -2151,6 +2166,31 @@ class Window_Base
     posX -= viewport.x if (viewport)
     posY -= viewport.y if (viewport)
     return(posX.between?(0, self.width-1) && posY.between?(0, self.height-1))
+  end
+  #--------------------------------------------------------------------------
+  # * Change Windowskin
+  #--------------------------------------------------------------------------
+  def change_windowskin(filename)
+    self.windowskin = Cache.windowskin(filename)
+  end
+  #--------------------------------------------------------------------------
+  # * Change Window tone
+  #--------------------------------------------------------------------------
+  def change_tone(tone)
+    @custom_tone = true
+    self.tone.set(tone)
+  end
+  #--------------------------------------------------------------------------
+  # * Use default windowskin
+  #--------------------------------------------------------------------------
+  def use_default_windowskin
+    self.windowskin = Cache.system("Window")
+  end
+  #--------------------------------------------------------------------------
+  # * Use default window tone
+  #--------------------------------------------------------------------------
+  def use_default_tone
+    @custom_tone = false
   end
 end
 


### PR DESCRIPTION
## Changes
- Adds commands to change or reset windowskin and tone in Window_Base
- Add commands `window_change_windowskin`, `window_change_tone` to change those elements for RME Windows
- Add commands `window_use_default_windowskin, `window_use_default_tone` to restore defaults to RME windows

Fixes #322
Fixes #323