### PR TITLE
Correction du bug de la chenille

### DIFF
--- a/RME.rb
+++ b/RME.rb
@@ -8015,6 +8015,8 @@ class Sprite_Character
   def set_character_bitmap
     rm_extender_set_character_bitmap
     if character.changing_graphics || (character.ox.nil? && character.oy.nil?)
+      character.ox = @cw / 2
+      character.oy = @ch
       character.ox = self.ox
       character.oy = self.oy
     else


### PR DESCRIPTION
J'ai rencontré un bug au niveau de la chenille, après des tests je me suis rendu compte que ça venait d'RME.
Pour produire ce bug : 
- Il faut commencer le jeu en activant la chenille en étant seul dans l'équipe.
- Dès qu'on ajoute des personnages à travers un événement ou une commande de script, les followers apparaissent en décaler.
En fait, s'il y a déjà des followers de bases dans l'équipe lors du démarrage du jeu, ils sont bien placé. Par contre, si un follower est ajouté dans une place où il n'y a pas eu de follower lors du démarrage, alors il apparaîtra en décaler.
Après diverses expériences, j'ai remarqué que cela venant de la valeur ox et oy qui sont mis à 0 et qui ne sont pas mis à jour lors d'un changement d'apparence.
J'ai donc ajouté 2 lignes, qui donne donc la bonne valeur à character.ox et character.oy, ce qui fait que le bug n'y est plus.